### PR TITLE
chore: making renovate aware of the socketzero helm chart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ uds deploy bundle/uds-bundle-socketzero-<arch>-0.0.1.tar.zst --confirm \
 
 ### Key Components
 
-1. **SocketZero Application** - Deployed via Helm chart from https://github.com/radiusmethod/socketzero-helm.git (v0.6.2)
+1. **SocketZero Application** - Deployed via Helm chart from https://github.com/radiusmethod/socketzero-helm.git (v0.7.0)
 2. **Redis** - Bundled dependency using Iron Bank image (`registry1.dso.mil/ironbank/bitnami/redis:8.0.3`)
 3. **UDS Package Resource** - Configures SSO integration and network policies in `chart/templates/uds-package.yaml`
 4. **Values Files** - Environment-specific configurations in `values/` directory
@@ -77,7 +77,7 @@ uds deploy bundle/uds-bundle-socketzero-<arch>-0.0.1.tar.zst --confirm \
 ## Image Registry
 
 Uses Registry1 Iron Bank images:
-- `registry1.dso.mil/ironbank/radiusmethod/socketzero/receiver:0.6.2`
+- `registry1.dso.mil/ironbank/radiusmethod/socketzero/receiver:0.7.0`
 - `registry1.dso.mil/ironbank/bitnami/redis:8.0.3`
 
 ## Variables

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,18 @@
     "workarounds:all"
   ],
   "schedule": ["after 7am and before 9am every weekday"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["common/zarf\\.yaml$", "zarf\\.yaml$", "values/.*\\.yaml$", "CLAUDE\\.md$"],
+      "matchStrings": [
+        "radiusmethod/socketzero.*?:(?<currentValue>\\d+\\.\\d+\\.\\d+)",
+        "socketzero-helm\\.git[\\s\\S]*?version:\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "radiusmethod/socketzero-helm",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
   "packageRules": [
     {
       "groupName": "SocketZero Support Dependencies",


### PR DESCRIPTION
## Description

Makes renovate aware of the `socketzero-helm` repo.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/uds-packages/uds-package-socketzero/blob/main/CONTRIBUTING.md#developer-workflow) followed
